### PR TITLE
Add autocomplete endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cors": "^2.8.1",
     "dbpedia-spotlight": "^0.5.27",
     "dotenv": "^4.0.0",
+    "elasticsearch": "^12.1.3",
     "express": "^4.14.1",
     "express-graphql": "^0.6.3",
     "flat": "^2.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ require('dotenv').load({ silent: true });
 export const {
   PORT = 4000,
   CAYLEY_ADDRESS = 'http://cayley:64210',
+  ELASTICSEARCH_ADDRESS = 'http://localhost:9200',
+  ELASTICSEARCH_INDEX_NAME = 'knowledge',
   MAG_API_ENDPOINT = 'https://academic.microsoft.com/api/browse/GetEntityDetails',
   DBPEDIA_ENDPOINT = 'http://dbpedia.org/resource/',
   DBPEDIA_SPARQL_ENDPOINT = 'http://dbpedia.org/sparql',

--- a/src/elasticsearch.ts
+++ b/src/elasticsearch.ts
@@ -1,0 +1,27 @@
+import elasticsearch = require('elasticsearch');
+
+import {
+  ELASTICSEARCH_ADDRESS,
+  ELASTICSEARCH_INDEX_NAME
+} from './config';
+
+const client = new elasticsearch.Client( {
+  host: ELASTICSEARCH_ADDRESS,
+  apiVersion: '5.x'
+});
+
+export function query(query: string): Promise<Array<Object>> {
+  return new Promise((resolve, reject) => {
+    client.search({
+      index: ELASTICSEARCH_INDEX_NAME,
+      body: query
+    }, (err, res) => {
+      if (err) return reject(err);
+      return resolve(res);
+    });
+  }).then((res: any) => {
+    return res.hits.hits;
+  });
+};
+
+export default query;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import * as graphqlHTTP from 'express-graphql';
 
 import Schema from './schema';
 
+import Elasticsearch from './elasticsearch';
 
 export function create() {
   const server = express();
@@ -20,6 +21,22 @@ export function create() {
 
   // Disable favicon
   server.get('/favicon.ico', (req, res, next) => res.status(404).end());
+
+  server.get('/autocomplete', (req, res) => {
+    let { text } = req.query;
+    let query = `{
+      "size": 5,
+      "_source": "name",
+      "query": {
+        "match": {
+          "name": "${text}"
+        }
+      }
+    }`;
+    Elasticsearch(query).then(results => {
+      res.json(results).end();
+    }).catch(err => res.status(500).json(err).end());
+  });
 
   server.all('/', graphqlHTTP({
     schema: Schema,


### PR DESCRIPTION
This PR adds an `/autocomplete` endpoint that uses Elasticsearch completion suggesters to provide an autocomplete for fields of study.