### PR TITLE
Move description and image to entity

### DIFF
--- a/src/schema/entity.ts
+++ b/src/schema/entity.ts
@@ -40,6 +40,27 @@ export const EntityType: BuilderObjectType<GraphQLBuilder> = new BuilderObjectTy
         return deirify(Context.Knowledge.Entity);
       }
     },
+    name: {
+      type: GraphQLString,
+      build: buildAttribute('name', Context.GraphQL.NAME),
+      resolve(source, args, context, info) {
+        return source.name;
+      }
+    },
+    description: {
+      type: GraphQLString,
+      build: buildAttribute('description', Context.GraphQL.DESCRIPTION),
+      resolve(source, args, context, info) {
+        return source.description;
+      }
+    },
+    image: {
+      type: GraphQLString,
+      build: buildAttribute('image', Context.GraphQL.IMAGE),
+      resolve(source, args, context, info) {
+        return source.image;
+      }
+    },
     fieldsOfStudy: {
       type: new GraphQLList(FieldOfStudyType),
       build: buildRelationship('fieldsOfStudy', `${Context.sameAs} @rev`),

--- a/src/schema/field_of_study.ts
+++ b/src/schema/field_of_study.ts
@@ -35,20 +35,6 @@ export const FieldOfStudyType: BuilderObjectType<GraphQLBuilder> = new BuilderOb
         return source.name;
       }
     },
-    description: {
-      type: GraphQLString,
-      build: buildAttribute('description', Context.GraphQL.DESCRIPTION),
-      resolve(source, args, context, info) {
-        return source.description;
-      }
-    },
-    image: {
-      type: GraphQLString,
-      build: buildAttribute('image', Context.GraphQL.IMAGE),
-      resolve(source, args, context, info) {
-        return source.image;
-      }
-    },
     entities: {
       type: new GraphQLList(EntityType),
       build: buildRelationship('entities', Context.sameAs),

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -57,16 +57,16 @@ export const Schema = new GraphQLSchema({
         build: buildRootType('topic', Context.Knowledge.Topic),
         resolve: resolveRootType('topic')
       },
-      // entity: {
-      //   type: EntityType,
-      //   args: {
-      //     id: {
-      //       type: GraphQLString,
-      //     }
-      //   },
-      //   build: buildRootType('entity', Context.Knowledge.Entity),
-      //   resolve: resolveRootType('entity')
-      // },
+      entity: {
+        type: EntityType,
+        args: {
+          id: {
+            type: GraphQLString,
+          }
+        },
+        build: buildRootType('entity', Context.Knowledge.Entity),
+        resolve: resolveRootType('entity')
+      },
       resource: {
         type: FieldOfStudyType,
         args: {
@@ -135,18 +135,8 @@ export const Schema = new GraphQLSchema({
             type: GraphQLInt
           }
         },
-        // build: buildRootType('entities', Context.Knowledge.Entity),
-        // resolve: resolveRootType('entities', true)
-        build(builder: GraphQLBuilder, { id, name }, path) {
-          return builder.filter({ id: `<${id}>` });
-        },
-        resolve(source, { }, context, info) {
-          let { operation: node, parentType: type } = info;
-          let base = new GraphQLBuilder('nodes',);
-          let builder = build(node, <BuilderObjectType<GraphQLBuilder>>type, base, 'entities');
-          let query = `{ ${builder.toString()} }`;
-          return cayley(query).then((res: any) => [].concat(res.nodes));
-        }
+        build: buildRootType('entities', Context.Knowledge.Entity),
+        resolve: resolveRootType('entities', true)
       },
       resources: {
         type: new GraphQLList(ResourceInterfaceType),


### PR DESCRIPTION
This PR enables entity lookup by type, allowing uniform handling of the data in Cayley by always starting traversels from the nodes that match the requested type. The PR also moves some attributes from `fieldsOfStudy` to `entities`.